### PR TITLE
Update check_time()

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -16,6 +16,7 @@
 from datetime import datetime, timedelta, timezone
 from django.test import TestCase
 from django.contrib.auth import get_user_model
+from rest_framework.fields import DateTimeField
 from rest_framework.test import APITestCase
 from rest_framework import status
 
@@ -58,7 +59,7 @@ class 여러가지테스트(APITestCase):
 
     def check_time(self, iso, t):
         # Compare equality of iso 8601 formatted string and datetime
-        self.assertEqual(datetime.strptime(iso, "%Y-%m-%dT%H:%M:%S%z"), t)
+        self.assertEqual(DateTimeField().to_internal_value(iso), t)
 
     def meeting(self, since, til):
         # Assemble a meeting object


### PR DESCRIPTION
Python 3.6.7 기준, datetime.datetime.strptime()이 "Z"를 시간대(`%z`)로 인식하지 못하는 문제가 있습니다. 이를 해결하기 위해, datetime 자료형의 serialization을 담당하는 rest_framework의 DateTimeField()에서 ISO 8601 String을 다루도록 코드를 수정해 보았습니다. 이 경우 별도의 복잡한 로직 없이 마이크로세컨드 단위도 받을 수 있다는 장점도 생깁니다!

```
Python 3.6.7 (v3.6.7:6ec5cf24b7, Oct 20 2018, 13:35:33) [MSC v.1900 64 bit (AMD64)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> from datetime import datetime
>>> datetime.strptime("Z", "%z")
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "C:\Users\lg\AppData\Local\Programs\Python\Python36\lib\_strptime.py", line 565, in _strptime_datetime
    tt, fraction = _strptime(data_string, format)
  File "C:\Users\lg\AppData\Local\Programs\Python\Python36\lib\_strptime.py", line 362, in _strptime
    (data_string, format))
ValueError: time data 'Z' does not match format '%z'
```